### PR TITLE
fix: add lints from lib.rs to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ thiserror = "1.0.61"
 
 [lib]
 doctest = true
+
+[lints]
+rust.missing_debug_implementations = "warn"
+rust.missing_docs = "warn"
+rust.unreachable_pub = "warn"
+rustdoc.all = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,6 @@
 //! # EOF Parser
 
-#![warn(
-    missing_debug_implementations,
-    unreachable_pub,
-    clippy::missing_const_for_fn,
-    rustdoc::all
-)]
+#![warn(clippy::missing_const_for_fn,)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]


### PR DESCRIPTION
if warning can be added to lib.rs why not add the same warning thru out the whole crate? since the whole project is a library, therfore proper documentation is required.